### PR TITLE
Remove override for robots

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,7 +5,6 @@ theme = "jacobproffer"
 paginate = 12
 paginatePath = "posts"
 copyright = "2024"
-enableRobotsTXT = true
 timeout = 60000
 ignoreErrors = ["error-disable-taxonomy"]
 

--- a/themes/jacobproffer/layouts/_default/baseof.html
+++ b/themes/jacobproffer/layouts/_default/baseof.html
@@ -39,6 +39,12 @@
 
     {{ template "_internal/twitter_cards.html" . }}
 
+    {{ if .IsHome }}
+      <link rel="canonical" href="{{ .Site.BaseURL }}"/>
+    {{ else }}
+      <link rel="canonical" href="{{ .Permalink }}"/>
+    {{ end }}
+
     <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png">


### PR DESCRIPTION
Setting `enableRobotsTXT` expects a custom robots.txt file.